### PR TITLE
Add monitoring for api-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,52 @@
 
 Terraform module to setup cloudwatch alerts and push them to SNS. This repository contains the following modules:
 
-* `kinesis`: Creates alerts for a kinesis stream. This is used in the `skyscrapers/terraform-kinesis` module.
+* `api-gateway`: Creates general alerts for the api-gateway.
 * `dynamodb`: Creates the alerts needed for a dynamodb table.
+* `kinesis`: Creates alerts for a kinesis stream. This is used in the `skyscrapers/terraform-kinesis` module.
 * `lambda_function`: Creates the alerts for lambda functions.
 
+## api-gateway
+
+Creates general alerts for the api-gateway
+
+The following resources are created:
+
+* Cloudwatch alerts for the api-gateway that was passed as variable
+
+### Available variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| 5XXError\_error\_period | The period in seconds over which the specified stat is applied. | string | `"60"` | no |
+| 5XXError\_evaluation\_periods | The number of periods over which data is compared to the specified threshold. | string | `"1"` | no |
+| 5XXError\_threshold | The value against which the specified statistic is compared. | string | `"5"` | no |
+| api\_gateway | Name of the API Gateway to monitor | string | n/a | yes |
+| integrationlatency\_error\_period | The period in seconds over which the specified stat is applied. | string | `"60"` | no |
+| integrationlatency\_evaluation\_periods | The number of periods over which data is compared to the specified threshold. | string | `"2"` | no |
+| integrationlatency\_threshold | The value against which the specified statistic is compared. | string | `"5000"` | no |
+| latency\_error\_period | The period in seconds over which the specified stat is applied. | string | `"60"` | no |
+| latency\_evaluation\_periods | The number of periods over which data is compared to the specified threshold. | string | `"2"` | no |
+| latency\_threshold | The value against which the specified statistic is compared. | string | `"5000"` | no |
+| sns\_topic\_arn | ARN of the SNS topic you want the alerts to be sent to | string | n/a | yes |
+
+## dynamodb
+
+Creates the alerts needed for a dynamodb table.
+
+### Available variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| dynamodb\_table\_name | Name of the dynamodb table to monitor | string | n/a | yes |
+| dynamodb\_throttle\_evaluation\_periods | The period in seconds over which the specified stat is applied. | string | `"1"` | no |
+| dynamodb\_throttle\_period | The number of periods over which data is compared to the specified threshold. | string | `"60"` | no |
+| dynamodb\_throttle\_threshold | The value against which the specified statistic is compared. | string | `"0"` | no |
+| sns\_topic\_arn | ARN of the SNS topic you want the alerts to be sent to | string | n/a | yes |
+
+
 ## kinesis
+
 Creates alerts for a kinesis stream. This is used in the `skyscrapers/terraform-kinesis` module.
 
 The following resources are created:
@@ -24,20 +65,6 @@ The following resources are created:
 | kinesis\_write\_throughput\_exceeded\_evaluation\_periods | The number of periods over which data is compared to the specified threshold. | string | `"6"` | no |
 | kinesis\_write\_throughput\_exceeded\_period | The period in seconds over which the specified stat is applied. | string | `"300"` | no |
 | kinesis\_write\_throughput\_exceeded\_threshold | The value against which the specified statistic is compared. | string | `"10"` | no |
-| sns\_topic\_arn | ARN of the SNS topic you want the alerts to be sent to | string | n/a | yes |
-
-## dynamodb
-
-Creates the alerts needed for a dynamodb table.
-
-### Available variables
-
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| dynamodb\_table\_name | Name of the dynamodb table to monitor | string | n/a | yes |
-| dynamodb\_throttle\_evaluation\_periods | The period in seconds over which the specified stat is applied. | string | `"1"` | no |
-| dynamodb\_throttle\_period | The number of periods over which data is compared to the specified threshold. | string | `"60"` | no |
-| dynamodb\_throttle\_threshold | The value against which the specified statistic is compared. | string | `"0"` | no |
 | sns\_topic\_arn | ARN of the SNS topic you want the alerts to be sent to | string | n/a | yes |
 
 ## lambda_function

--- a/api_gateway/main.tf
+++ b/api_gateway/main.tf
@@ -1,0 +1,59 @@
+// Setup Cloudwatch alarms for passed API gateway
+// Send alerts to given SNS topics.
+
+resource "aws_cloudwatch_metric_alarm" "ApiGateway_5XXError" {
+  alarm_name          = "${var.api_gateway}_5XXError"
+  alarm_description   = "The errors on ${var.api_gateway} are higher than ${var.5XXError_treshold} for ${var.5XXError_period}"
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "5XXError"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "${var.5XXError_treshold}"
+  evaluation_periods  = "${var.5XXError_evaluation_periods}"
+  period              = "${var.5XXError_period}"
+
+  alarm_actions = ["${var.sns_topic_arn}"]
+  ok_actions    = ["${var.sns_topic_arn}"]
+
+  dimensions {
+    FunctionName = "${var.api_gateway}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ApiGateway_latency" {
+  alarm_name          = "${var.api_gateway}_latency"
+  alarm_description   = "The latency on ${var.api_gateway} is higher than ${var.latency_treshold} for ${var.latency_period}"
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "Latency"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "${var.latency_treshold}"
+  evaluation_periods  = "${var.latency_evaluation_periods}"
+  period              = "${var.latency_period}"
+
+  alarm_actions = ["${var.sns_topic_arn}"]
+  ok_actions    = ["${var.sns_topic_arn}"]
+
+  dimensions {
+    FunctionName = "${var.api_gateway}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ApiGateway_integrationlatency" {
+  alarm_name          = "${var.api_gateway}_integrationlatency"
+  alarm_description   = "The latency on ${var.api_gateway} is higher than ${var.integrationlatency_treshold} for ${var.integrationlatency_period}"
+  namespace           = "AWS/ApiGateway"
+  metric_name         = "IntegrationLatency"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "${var.integrationlatency_treshold}"
+  evaluation_periods  = "${var.integrationlatency_evaluation_periods}"
+  period              = "${var.integrationlatency_period}"
+
+  alarm_actions = ["${var.sns_topic_arn}"]
+  ok_actions    = ["${var.sns_topic_arn}"]
+
+  dimensions {
+    FunctionName = "${var.api_gateway}"
+  }
+}

--- a/api_gateway/variables.tf
+++ b/api_gateway/variables.tf
@@ -1,0 +1,60 @@
+variable "sns_topic_arn" {
+  description = "ARN of the SNS topic you want the alerts to be sent to"
+}
+
+// API Gateway name
+variable "api_gateway" {
+  type        = "string"
+  description = "Name of the API Gateway to monitor"
+}
+
+// API Gateway 5XXError Alarm Settings
+
+variable "5XXError_threshold" {
+  default     = "5"
+  description = "The value against which the specified statistic is compared."
+}
+
+variable "5XXError_evaluation_periods" {
+  default     = "1"
+  description = "The number of periods over which data is compared to the specified threshold."
+}
+
+variable "5XXError_error_period" {
+  default     = "60"
+  description = "The period in seconds over which the specified stat is applied."
+}
+
+// API Gateway Latency Alarm Settings
+
+variable "latency_threshold" {
+  default     = "5000"
+  description = "The value against which the specified statistic is compared."
+}
+
+variable "latency_evaluation_periods" {
+  default     = "2"
+  description = "The number of periods over which data is compared to the specified threshold."
+}
+
+variable "latency_error_period" {
+  default     = "60"
+  description = "The period in seconds over which the specified stat is applied."
+}
+
+// API Gateway IntegrationLatency Alarm Settings
+
+variable "integrationlatency_threshold" {
+  default     = "5000"
+  description = "The value against which the specified statistic is compared."
+}
+
+variable "integrationlatency_evaluation_periods" {
+  default     = "2"
+  description = "The number of periods over which data is compared to the specified threshold."
+}
+
+variable "integrationlatency_error_period" {
+  default     = "60"
+  description = "The period in seconds over which the specified stat is applied."
+}


### PR DESCRIPTION
This PR adds:
- a terraform module that provisions triggers for api-gateways in cloudwatch
- documentation on how to use the module