### PR TITLE
Add variable treat_missing_data on lambda alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following resources are created:
 | lambda\_invocation\_error\_evaluation\_periods | The number of periods over which data is compared to the specified threshold. | string | `"1"` | no |
 | lambda\_invocation\_error\_period | The period in seconds over which the specified stat is applied. | string | `"60"` | no |
 | lambda\_invocation\_error\_threshold | The value against which the specified statistic is compared. | string | `"5"` | no |
+| lambda\_invocation\_error\_treat\_missing\_data | Sets how this alarm is to handle missing data points. | string | `"missing"` | no |
 | lambda\_iterator\_age\_error\_evaluation\_periods | The number of periods over which data is compared to the specified threshold. | string | `"1"` | no |
 | lambda\_iterator\_age\_error\_period | The period in seconds over which the specified stat is applied. | string | `"60"` | no |
 | lambda\_iterator\_age\_error\_threshold | The value against which the specified statistic is compared. | string | `"1000000"` | no |

--- a/lambda_function/main.tf
+++ b/lambda_function/main.tf
@@ -12,6 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_invocation_errors" {
   threshold           = var.lambda_invocation_error_threshold
   evaluation_periods  = var.lambda_invocation_error_evaluation_periods
   period              = var.lambda_invocation_error_period
+  treat_missing_data  = var.lambda_invocation_error_treat_missing_data
 
   alarm_actions = [var.sns_topic_arn]
   ok_actions    = [var.sns_topic_arn]
@@ -60,4 +61,3 @@ resource "aws_cloudwatch_metric_alarm" "streamalert_lambda_iterator_age" {
     FunctionName = var.lambda_function
   }
 }
-

--- a/lambda_function/variables.tf
+++ b/lambda_function/variables.tf
@@ -25,6 +25,12 @@ variable "lambda_invocation_error_period" {
   description = "The period in seconds over which the specified stat is applied."
 }
 
+variable "lambda_invocation_error_treat_missing_data" {
+  type        = string
+  default     = "missing"
+  description = "Sets how this alarm is to handle missing data points"
+}
+
 // Lambda Throttling Alarm Settings
 variable "lambda_throttle_error_threshold" {
   default     = "0"
@@ -56,4 +62,3 @@ variable "lambda_iterator_age_error_period" {
   default     = "60"
   description = "The period in seconds over which the specified stat is applied."
 }
-


### PR DESCRIPTION
This allows setting the treat_missing_data property for the invocation errors alarm for lambda functions. Defaults to the provider default, so shouldn't break current instalations.